### PR TITLE
Add swarm bootstrapping with the resource plugin

### DIFF
--- a/swarm/README.md
+++ b/swarm/README.md
@@ -1,5 +1,24 @@
 # InfraKit + Docker Swarm Mode
 
+This example bootstraps a Docker swarm running with InfraKit for infrastructure
+monitoring and orchestration.
 
-This example uses AWS Cloudformation to bootstrap a Docker Swarm running with Infrakit for infrastructure
-monitoring and orchestration.  To test it out, use the CFN script found in [aws/vpc.cfn](aws/vpc.cfn).
+## AWS using CloudFormation
+
+To bootstrap a Docker swarm on AWS using CloudFormation, use the CloudFormation
+template found in [aws/vpc.cfn](aws/vpc.cfn).
+
+## AWS using the InfraKit resource plugin
+
+To bootstrap a Docker swarm on AWS using the InfraKit resource plugin, use the InfraKit
+resource plugin template found in [aws/vpn.ikt](aws/vpn.ikt).
+
+```sh
+docker run -d -v $HOME/.infrakit:/infrakit infrakit/aws:latest instance --region us-west-2 --access-key-id=... --secret-access-key=...
+
+docker run -d -v $HOME/.infrakit:/infrakit infrakit/devbundle:latest infrakit-resource
+
+docker run --rm -v $HOME/.infrakit:/infrakit infrakit/devbundle:latest infrakit resource commit \
+    https://infrakit.github.io/examples/swarm/aws/vpc.ikt \
+    --global /ec2/keyName=...
+```

--- a/swarm/aws/manager.json
+++ b/swarm/aws/manager.json
@@ -4,7 +4,7 @@ Instance plugin config for managers on AWS
 
 */}}
 {
-    "Plugin": "instance-aws",
+    "Plugin": "instance-aws/ec2-instance",
     "Properties": {
         "Tags": {
             "infrakit.clusterName": "{{ ref "/cluster/name" }}",

--- a/swarm/aws/vpc.cfn
+++ b/swarm/aws/vpc.cfn
@@ -46,17 +46,17 @@
         "InfrakitCore" : {
             "Type" : "String",
             "Description" : "Docker image of Infrakit",
-            "Default" : "infrakit/devbundle:0.4.1"
+            "Default" : "infrakit/devbundle:latest"
         },
         "InfrakitInstancePlugin" : {
             "Type" : "String",
             "Description" : "Docker image of Infrakit AWS instance plugin",
-            "Default" : "infrakit/aws:0.4.1"
+            "Default" : "infrakit/aws:latest"
         },
         "InfrakitMetadataPlugin" : {
             "Type" : "String",
             "Description" : "Docker image of Infrakit AWS metadata plugin",
-            "Default" : "infrakit/aws:0.4.1"
+            "Default" : "infrakit/aws:latest"
         }
     },
 
@@ -406,7 +406,7 @@
                             {
                                 "Fn::FindInMap": [ "AMISelector", { "Ref" : "PreinstalledDockerAMI" }, "userdata" ]
                             },
-                            "docker run --rm infrakit/devbundle:dev infrakit template --url ",
+                            "docker run --rm ", {"Ref":"InfrakitCore"}, " infrakit template ",
                                {"Ref":"InfrakitConfigRoot"}, "/boot.sh",
                                " --global /cluster/name=", {"Ref":"AWS::StackName"},
                                " --global /cluster/swarm/size=", {"Ref":"ClusterSize"},

--- a/swarm/aws/vpc.ikt
+++ b/swarm/aws/vpc.ikt
@@ -1,0 +1,280 @@
+{{ def "/cluster/name" "MyTestCluster" }}
+{{ def "/cluster/swarm/size" "Number of swarm nodes to create" 4 }}
+{{ def "/ec2/availabilityZone" "EC2 Availability Zone" "us-west-2a" }}
+{{ def "/ec2/imageID" "EC2 Amazon Machine Image" "ami-c877f4a8" }}
+{{ def "/ec2/instanceType" "EC2 HVM instance type (t2.micro, m3.medium, etc)." "t2.micro" }}
+{{ def "/ec2/keyName" "EC2 key pair name" "ValidEC2KeyPairName" }}
+{{ def "/infrakit/config/root" "Root URL of the bootscript" "https://infrakit.github.io/examples/swarm" }}
+{{ def "/infrakit/docker/image" "Docker image of Infrakit" "infrakit/devbundle:0.4.1" }}
+{{ def "/infrakit/instance/docker/image" "Docker image of Infrakit AWS instance plugin" "infrakit/aws:0.4.1" }}
+{{ def "/infrakit/metadata/configURL" "URL to configure the metadata plugin" "https://infrakit.github.io/examples/metadata/aws/export.ikt" }}
+{{ def "/infrakit/metadata/docker/image" "Docker image of Infrakit AWS metadata plugin" "infrakit/aws:0.4.1" }}
+{{ def "/net/bootstrapNodePrivateIP" "Private IP of the bootstrap node" "172.31.16.101" }}
+{{ def "/net/subnetCidr" "172.31.16.0/20" }}
+{{ def "/net/vpcCidr" "172.31.0.0/16" }}
+
+{{ $clusterName := ref "/cluster/name" }}
+{{ $clusterSwarmSize := ref "/cluster/swarm/size" }}
+{{ $infrakitConfigRoot := ref "/infrakit/config/root" }}
+{{ $infrakitDockerImage := ref "/infrakit/docker/image" }}
+{{ $infrakitInstanceDockerPlugin := ref "/infrakit/instance/docker/image" }}
+{{ $infrakitMetadataConfigURL := ref "/infrakit/metadata/configURL" }}
+{{ $infrakitMetadataDockerImage := ref "/infrakit/metadata/docker/image" }}
+
+{
+    "ID": "{{ ref "/cluster/name" }}",
+    "Properties": {
+        "Resources": [
+
+            {
+                "ID": "Vpc",
+                "Plugin": "instance-aws/ec2-vpc",
+                "Properties": {
+                    "CreateVpcInput": {
+                        "CidrBlock": "{{ ref "/net/vpcCidr" }}"
+                    },
+                    "ModifyVpcAttributeInputs": [
+                        { "EnableDnsSupport": {"Value": true} },
+                        { "EnableDnsHostnames": {"Value": true} }
+                    ],
+                    "Tags": {
+                        "Name": "$clusterName{{ ref "/cluster/name" }}-VPC"
+                    }
+                }
+            },
+
+            {
+                "ID": "Subnet",
+                "Plugin": "instance-aws/ec2-subnet",
+                "Properties": {
+                    "CreateSubnetInput": {
+                        "VpcId": "{{ resource "Vpc" }}",
+                        "CidrBlock": "{{ ref "/net/subnetCidr" }}",
+                        "AvailabilityZone": "{{ ref "/ec2/availabilityZone" }}"
+                    },
+                    "Tags": {
+                        "Name": "{{ ref "/cluster/name" }}-Subnet"
+                    }
+                }
+            },
+
+            {
+                "ID": "InternetGateway",
+                "Plugin": "instance-aws/ec2-internetgateway",
+                "Properties": {
+                    "CreateInternetGatewayIntput": {},
+                    "AttachInternetGatewayInput": {
+                        "VpcId": "{{ resource "Vpc" }}"
+                    },
+                    "Tags": {
+                        "Name": "{{ ref "/cluster/name" }}-IGW"
+                    }
+                }
+            },
+
+            {
+                "ID": "RouteViaIgw",
+                "Plugin": "instance-aws/ec2-routetable",
+                "Properties": {
+                    "CreateRouteTableInput": {
+                        "VpcId": "{{ resource "Vpc" }}"
+                    },
+                    "CreateRouteInputs": [
+                        {
+                            "DestinationCidrBlock": "0.0.0.0/0",
+                            "GatewayId": "{{ resource "InternetGateway" }}"
+                        }
+                    ],
+                    "AssociateRouteTableInputs": [
+                        {
+                            "SubnetId": "{{ resource "Subnet" }}"
+                        }
+                    ],
+                    "Tags": {
+                        "Name": "{{ ref "/cluster/name" }}-RT"
+                    }
+                }
+            },
+
+            {
+                "ID": "SecurityGroup",
+                "Plugin": "instance-aws/ec2-securitygroup",
+                "Properties": {
+                    "CreateSecurityGroupInput": {
+                        "Description": "VPC-wide security group",
+                        "VpcId": "{{ resource "Vpc" }}"
+                    },
+                    "AuthorizeSecurityGroupIngressInput": {
+                        "IpPermissions": [
+                            {
+                                "IpProtocol": "-1",
+                                "FromPort": 0,
+                                "ToPort": 65535,
+                                "IpRanges": [
+                                    {
+                                        "CidrIp": "{{ ref "/net/vpcCidr" }}"
+                                    }
+                                ]
+                            },
+                            {
+                                "IpProtocol": "tcp",
+                                "FromPort": 22,
+                                "ToPort": 22,
+                                "IpRanges": [
+                                    {
+                                        "CidrIp": "0.0.0.0/0"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+
+            {
+                "ID": "ProvisionerRole",
+                "Plugin": "instance-aws/iam-role",
+                "Properties": {
+                    "CreateRoleInput": {
+                        "AssumeRolePolicyDocument": {{ `{
+                            "Version": "2012-10-17",
+                            "Statement": [ {
+                                "Effect": "Allow",
+                                "Principal": {
+                                    "Service": [ "ec2.amazonaws.com" ]
+                                },
+                                "Action": [ "sts:AssumeRole" ]
+                            } ]
+                        }` | jsonEncode }}
+                    },
+                    "PutRolePolicyInputs": [
+                        {
+                            "PolicyDocument": {{ `{
+                                "Version": "2012-10-17",
+                                "Statement": [
+                                    {
+                                        "Effect": "Allow",
+                                        "Action": "*",
+                                        "Resource": "*"
+                                    }
+                                ]
+                            }` | jsonEncode }}
+                        }
+                    ]
+                }
+            },
+
+            {
+                "ID": "InstanceProfile",
+                "Plugin": "instance-aws/iam-instanceprofile",
+                "Properties": {
+                    "CreateInstanceProfileInput": {},
+                    "AddRoleToInstanceProfileInput": {
+                        "RoleName": "{{ resource "ProvisionerRole" }}"
+                    }
+                }
+            },
+
+            {
+                "ID": "Volume1",
+                "Plugin": "instance-aws/ec2-volume",
+                "Properties": {
+                    "CreateVolumeInput": {
+                        "AvailabilityZone": "{{ ref "/ec2/availabilityZone" }}",
+                        "Size": 4
+                    },
+                    "Tags": {
+                        "Name": "{{ ref "/cluster/name" }}-EBS",
+                        "infrakit.scope": "{{ ref "/cluster/name" }}",
+                        "docker-infrakit-volume": "172.31.16.101"
+                    }
+                }
+            },
+
+            {
+                "ID": "Volume2",
+                "Plugin": "instance-aws/ec2-volume",
+                "Properties": {
+                    "CreateVolumeInput": {
+                        "AvailabilityZone": "{{ ref "/ec2/availabilityZone" }}",
+                        "Size": 4
+                    },
+                    "Tags": {
+                        "Name": "{{ ref "/cluster/name" }}-EBS",
+                        "infrakit.scope": "{{ ref "/cluster/name" }}",
+                        "docker-infrakit-volume": "172.31.16.102"
+                    }
+                }
+            },
+
+            {
+                "ID": "Volume3",
+                "Plugin": "instance-aws/ec2-volume",
+                "Properties": {
+                    "CreateVolumeInput": {
+                        "AvailabilityZone": "{{ ref "/ec2/availabilityZone" }}",
+                        "Size": 4
+                    },
+                    "Tags": {
+                        "Name": "{{ ref "/cluster/name" }}-EBS",
+                        "infrakit.scope": "{{ ref "/cluster/name" }}",
+                        "docker-infrakit-volume": "172.31.16.103"
+                    }
+                }
+            },
+
+            {
+                "ID": "BootstrapInstance",
+                "Plugin": "instance-aws/ec2-instance",
+                "Properties": {
+                    "RunInstancesInput": {
+                        "IamInstanceProfile": {"Name": "{{ resource "InstanceProfile" }}"},
+                        "ImageId": "{{ ref "/ec2/imageID" }}",
+                        "InstanceType": "{{ ref "/ec2/instanceType" }}",
+                        "KeyName": "{{ ref "/ec2/keyName" }}",
+                        "NetworkInterfaces": [
+                            {
+                                "AssociatePublicIpAddress": true,
+                                "DeleteOnTermination": true,
+                                "DeviceIndex": 0,
+                                "Groups": ["{{ resource "SecurityGroup" }}"],
+                                "PrivateIpAddress": "{{ ref "/net/bootstrapNodePrivateIP" }}",
+                                "SubnetId": "{{ resource "Subnet" }}"
+                            }
+                        ],
+                        "Placement": {"AvailabilityZone":  "{{ ref "/ec2/availabilityZone" }}"},
+                        "UserData": {{ print `#!/bin/sh
+
+docker 2>/dev/null || wget -qO- https://get.docker.com/ | sh
+
+docker run --rm infrakit/devbundle:dev infrakit template --url ` $infrakitConfigRoot `/boot.sh \
+    --global /cluster/name=` $clusterName ` \
+    --global /cluster/swarm/size=` $clusterSwarmSize ` \
+    --global /infrakit/config/root=` $infrakitConfigRoot ` \
+    --global /infrakit/docker/image=` $infrakitDockerImage ` \
+    --global /infrakit/instance/docker/image=` $infrakitInstanceDockerPlugin ` \
+    --global /infrakit/metadata/configURL=` $infrakitMetadataConfigURL ` \
+    --global /infrakit/metadata/docker/image=` $infrakitMetadataDockerImage ` \
+    --global /provider/image/hasDocker=yes \
+    | tee /var/lib/infrakit.boot | sh
+` | jsonEncode }}
+                    },
+                    "AttachVolumeInputs": [
+                        {
+                            "Device": "/dev/xvdf",
+                            "VolumeId": "{{ resource "Volume1" }}"
+                        }
+                    ],
+                    "Tags": {
+                        "Name": "{{ ref "/cluster/name" }}-Bootstrap",
+                        "infrakit.scope": "{{ ref "/cluster/name" }}",
+                        "infrakit.group": "swarm-managers",
+                        "infrakit.config_sha": "bootstrap",
+                        "infrakit.role": "managers"
+                    }
+                }
+            }
+
+        ]
+    }
+}

--- a/swarm/aws/vpc.ikt
+++ b/swarm/aws/vpc.ikt
@@ -1,25 +1,18 @@
 {{ def "/cluster/name" "MyTestCluster" }}
-{{ def "/cluster/swarm/size" "Number of swarm nodes to create" 4 }}
+{{ def "/cluster/swarm/size" "Number of swarm nodes to create.  Three will be managers; the rest, workers." 4 }}
 {{ def "/ec2/availabilityZone" "EC2 Availability Zone" "us-west-2a" }}
 {{ def "/ec2/imageID" "EC2 Amazon Machine Image" "ami-c877f4a8" }}
 {{ def "/ec2/instanceType" "EC2 HVM instance type (t2.micro, m3.medium, etc)." "t2.micro" }}
 {{ def "/ec2/keyName" "EC2 key pair name" "ValidEC2KeyPairName" }}
 {{ def "/infrakit/config/root" "Root URL of the bootscript" "https://infrakit.github.io/examples/swarm" }}
-{{ def "/infrakit/docker/image" "Docker image of Infrakit" "infrakit/devbundle:latest" }}
-{{ def "/infrakit/instance/docker/image" "Docker image of Infrakit AWS instance plugin" "infrakit/aws:latest" }}
+{{ def "/infrakit/docker/image" "Docker image of InfraKit" "infrakit/devbundle:latest" }}
+{{ def "/infrakit/instance/docker/image" "Docker image of InfraKit AWS instance plugin" "infrakit/aws:latest" }}
 {{ def "/infrakit/metadata/configURL" "URL to configure the metadata plugin" "https://infrakit.github.io/examples/metadata/aws/export.ikt" }}
-{{ def "/infrakit/metadata/docker/image" "Docker image of Infrakit AWS metadata plugin" "infrakit/aws:latest" }}
+{{ def "/infrakit/metadata/docker/image" "Docker image of InfraKit AWS metadata plugin" "infrakit/aws:latest" }}
 {{ def "/net/bootstrapNodePrivateIP" "Private IP of the bootstrap node" "172.31.16.101" }}
 {{ def "/net/subnetCidr" "172.31.16.0/20" }}
 {{ def "/net/vpcCidr" "172.31.0.0/16" }}
-
-{{ $clusterName := ref "/cluster/name" }}
-{{ $clusterSwarmSize := ref "/cluster/swarm/size" }}
-{{ $infrakitConfigRoot := ref "/infrakit/config/root" }}
-{{ $infrakitDockerImage := ref "/infrakit/docker/image" }}
-{{ $infrakitInstanceDockerPlugin := ref "/infrakit/instance/docker/image" }}
-{{ $infrakitMetadataConfigURL := ref "/infrakit/metadata/configURL" }}
-{{ $infrakitMetadataDockerImage := ref "/infrakit/metadata/docker/image" }}
+{{ def "/provider/image/hasDocker" "Does /ec2/imageID include Docker ('yes' or 'no')?" "yes" }}
 
 {
     "ID": "{{ ref "/cluster/name" }}",
@@ -38,7 +31,7 @@
                         { "EnableDnsHostnames": {"Value": true} }
                     ],
                     "Tags": {
-                        "Name": "$clusterName{{ ref "/cluster/name" }}-VPC"
+                        "Name": "{{ ref "/cluster/name" }}-VPC"
                     }
                 }
             },
@@ -247,15 +240,15 @@
 
 docker 2>/dev/null || wget -qO- https://get.docker.com/ | sh
 
-docker run --rm ` $infrakitDockerImage ` infrakit template ` $infrakitConfigRoot `/boot.sh \
-    --global /cluster/name=` $clusterName ` \
-    --global /cluster/swarm/size=` $clusterSwarmSize ` \
-    --global /infrakit/config/root=` $infrakitConfigRoot ` \
-    --global /infrakit/docker/image=` $infrakitDockerImage ` \
-    --global /infrakit/instance/docker/image=` $infrakitInstanceDockerPlugin ` \
-    --global /infrakit/metadata/configURL=` $infrakitMetadataConfigURL ` \
-    --global /infrakit/metadata/docker/image=` $infrakitMetadataDockerImage ` \
-    --global /provider/image/hasDocker=yes \
+docker run --rm ` (ref "/infrakit/docker/image") ` infrakit template ` (ref "/infrakit/config/root") `/boot.sh \
+    --global /cluster/name=` (ref "/cluster/name") ` \
+    --global /cluster/swarm/size=` (ref "/cluster/swarm/size") ` \
+    --global /infrakit/config/root=` (ref "/infrakit/config/root") ` \
+    --global /infrakit/docker/image=` (ref "/infrakit/docker/image") ` \
+    --global /infrakit/instance/docker/image=` (ref "/infrakit/instance/docker/image") ` \
+    --global /infrakit/metadata/configURL=` (ref "/infrakit/metadata/configURL") ` \
+    --global /infrakit/metadata/docker/image=` (ref "/infrakit/metadata/docker/image") ` \
+    --global /provider/image/hasDocker=` (ref "/provider/image/hasDocker") ` \
     | tee /var/lib/infrakit.boot | sh
 ` | jsonEncode }}
                     },

--- a/swarm/aws/vpc.ikt
+++ b/swarm/aws/vpc.ikt
@@ -5,10 +5,10 @@
 {{ def "/ec2/instanceType" "EC2 HVM instance type (t2.micro, m3.medium, etc)." "t2.micro" }}
 {{ def "/ec2/keyName" "EC2 key pair name" "ValidEC2KeyPairName" }}
 {{ def "/infrakit/config/root" "Root URL of the bootscript" "https://infrakit.github.io/examples/swarm" }}
-{{ def "/infrakit/docker/image" "Docker image of Infrakit" "infrakit/devbundle:0.4.1" }}
-{{ def "/infrakit/instance/docker/image" "Docker image of Infrakit AWS instance plugin" "infrakit/aws:0.4.1" }}
+{{ def "/infrakit/docker/image" "Docker image of Infrakit" "infrakit/devbundle:latest" }}
+{{ def "/infrakit/instance/docker/image" "Docker image of Infrakit AWS instance plugin" "infrakit/aws:latest" }}
 {{ def "/infrakit/metadata/configURL" "URL to configure the metadata plugin" "https://infrakit.github.io/examples/metadata/aws/export.ikt" }}
-{{ def "/infrakit/metadata/docker/image" "Docker image of Infrakit AWS metadata plugin" "infrakit/aws:0.4.1" }}
+{{ def "/infrakit/metadata/docker/image" "Docker image of Infrakit AWS metadata plugin" "infrakit/aws:latest" }}
 {{ def "/net/bootstrapNodePrivateIP" "Private IP of the bootstrap node" "172.31.16.101" }}
 {{ def "/net/subnetCidr" "172.31.16.0/20" }}
 {{ def "/net/vpcCidr" "172.31.0.0/16" }}
@@ -247,7 +247,7 @@
 
 docker 2>/dev/null || wget -qO- https://get.docker.com/ | sh
 
-docker run --rm infrakit/devbundle:dev infrakit template --url ` $infrakitConfigRoot `/boot.sh \
+docker run --rm ` $infrakitDockerImage ` infrakit template ` $infrakitConfigRoot `/boot.sh \
     --global /cluster/name=` $clusterName ` \
     --global /cluster/swarm/size=` $clusterSwarmSize ` \
     --global /infrakit/config/root=` $infrakitConfigRoot ` \

--- a/swarm/aws/worker.json
+++ b/swarm/aws/worker.json
@@ -4,7 +4,7 @@ Config for workers on AWS
 
 */}}
 {
-    "Plugin": "instance-aws",
+    "Plugin": "instance-aws/ec2-instance",
     "Properties": {
         "Tags": {
             "infrakit.clusterName": "{{ ref "/cluster/name" }}",

--- a/swarm/common.ikt
+++ b/swarm/common.ikt
@@ -13,7 +13,7 @@
 Integration with the metadata plugin here -- note the values here are from the cloudformation metadata
 if not available, we expect to come from command line or some other means -- see vpc.cfn boostrap node's userdata
 */}}
-{{ if metadata "var" }}
+{{ if metadata "var/export/cfn" }}
 {{ global "/cluster/name"                   ( metadata "var/export/cfn/stack" )}}
 {{ global "/cluster/swarm/size"             ( metadata "var/export/cfn/config/Parameters/ClusterSize/ParameterValue" )}}
 {{ global "/provider/image/hasDocker"       ( metadata "var/export/cfn/config/Parameters/PreinstalledDockerAMI/ParameterValue" )}}

--- a/swarm/groups.json
+++ b/swarm/groups.json
@@ -19,6 +19,17 @@ the instances it manages reside.
 {{ $workerSize := sub (ref "/cluster/swarm/size") (len $managerIPs) }}
 {{ $dockerEngine := "unix:///var/run/docker.sock" }} {{/* for this flavor to connect to */}}
 
+{{ $initFormatString := print `str://#!/bin/bash
+{{ global "/cluster/name" "` (ref "/cluster/name") `" }}
+{{ global "/cluster/swarm/size" "` (ref "/cluster/swarm/size") `" }}
+{{ global "/infrakit/config/root" "` (ref "/infrakit/config/root") `" }}
+{{ global "/infrakit/docker/image" "` (ref "/infrakit/docker/image") `" }}
+{{ global "/infrakit/instance/docker/image" "` (ref "/infrakit/instance/docker/image") `" }}
+{{ global "/infrakit/metadata/configURL" "` (ref "/infrakit/metadata/configURL") `" }}
+{{ global "/infrakit/metadata/docker/image" "` (ref "/infrakit/metadata/docker/image") `" }}
+{{ global "/provider/image/hasDocker" "` (ref "/provider/image/hasDocker") `" }}
+{{ include "%s" . }}
+` }}
 {{ $managerInit := cat (ref "/infrakit/config/root") "/manager-init.sh" | nospace }}
 {{ $workerInit := cat (ref "/infrakit/config/root") "/worker-init.sh" | nospace }}
 
@@ -47,7 +58,7 @@ the instances it manages reside.
                                 { "ID":"{{index $managerIPs 2}}", "Type":"ebs" }
                             ]
                         },
-                        "InitScriptTemplateURL": "{{ $managerInit }}",
+                        "InitScriptTemplateURL": {{ printf $initFormatString $managerInit | to_json}},
                         "SwarmJoinIP": "{{ $swarmLeaderIP }}",
                         "Docker" : {
                             "Host" : "{{ $dockerEngine }}"
@@ -70,7 +81,7 @@ the instances it manages reside.
                 "Flavor": {
                     "Plugin": "flavor-swarm/worker",
                     "Properties": {
-                        "InitScriptTemplateURL": "{{ $workerInit }}",
+                        "InitScriptTemplateURL": {{ printf $initFormatString $workerInit | to_json}},
                         "SwarmJoinIP": "{{ $swarmLeaderIP }}",
                         "Docker" : {
                             "Host" : "{{ $dockerEngine }}"

--- a/swarm/infrakit.sh
+++ b/swarm/infrakit.sh
@@ -26,6 +26,15 @@ alias infrakit='docker run --rm {{$dockerMounts}} {{$dockerEnvs}} {{$dockerImage
 
 {{ $groupsURL := cat (ref "/infrakit/config/root") "/groups.json" | nospace }}
 
+{{ $managerGlobals := trim `
+/cluster/name
+/cluster/swarm/size
+/infrakit/config/root
+/infrakit/docker/image
+/infrakit/instance/docker/image
+/infrakit/metadata/configURL
+/infrakit/metadata/docker/image
+/provider/image/hasDocker` | split "\n" }}
 
 echo "Starting up infrakit"
 docker run -d --restart always --name manager \
@@ -52,4 +61,4 @@ docker run -d --restart always --name metadata \
 sleep 10
 
 # Try to commit - this is idempotent but don't error out and stop the cloud init script!
-echo "Commiting to infrakit $(docker run --rm {{$dockerMounts}} {{$dockerEnvs}} {{$dockerImage}} infrakit manager commit {{$groupsURL}})"
+echo "Commiting to infrakit $(docker run --rm {{$dockerMounts}} {{$dockerEnvs}} {{$dockerImage}} infrakit manager commit {{$groupsURL}}{{range $k, $v := $managerGlobals}} --global {{$v -}}={{- ref $v}}{{end}})"


### PR DESCRIPTION
This PR adds a template that will bootstrap a swarm on AWS using the InfraKit resource plugin instead of CloudFormation. It depends on docker/infrakit#451 and docker/infrakit.aws#35.