### PR TITLE
Added quick test for upgrade container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.6
+MAINTAINER FrenchBen <FrenchBen@docker.com>
+COPY latest /src/
+WORKDIR /infrakit
+VOLUME ["/infrakit"]
+
+CMD ["cp", "-R", "/src/*", "/infrakit"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+TAG := 0.5
+NAMESPACE := infrakit
+UPGRADE_IMAGE := ${NAMESPACE}/upgrade:${TAG}
+
+build:
+	docker image build -t infrakit-test -f test/Dockerfile .
+	docker image build -t ${UPGRADE_IMAGE} -f Dockerfile .
+
+test: clean build
+	docker volume create infrakit 
+	docker container run -d -t --name infrakit-test -v infrakit:/infrakit infrakit-test
+	docker container run -d --name infrakit-upgrade -v infrakit:/infrakit ${UPGRADE_IMAGE} sh -c "sleep 10 && cp -R /src/* /infrakit"
+	docker exec -t infrakit-test watch -d cat /infrakit/swarm/infrakit.sh
+
+clean:
+	-docker container rm -f infrakit-test
+	-docker container rm -f infrakit-upgrade
+	-docker volume rm infrakit

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6
+MAINTAINER FrenchBen <FrenchBen@docker.com>
+RUN apk add --update --no-cache tini
+
+COPY latest /infratest
+COPY test/entry.sh /entry.sh
+RUN chmod +x /entry.sh
+ENTRYPOINT ["/sbin/tini", "--", "/entry.sh"]
+
+CMD ["top"]

--- a/test/entry.sh
+++ b/test/entry.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+mv /infratest/* /infrakit/
+sed -i 's/docker run/docker container run/' /infrakit/swarm/infrakit.sh
+
+eval "$@"


### PR DESCRIPTION
This PR shows how an upgrade container could be used to modify the template files that infrakit uses.
Here the `watch -d cat` container represents InfraKit - After 10seconds, we run the copy command.
To make this possible in the Makefile, the sleep is passed to the upgrade container. 
An admin would be able to run it directly to target InfraKit directly. 
