### PR TITLE
Added Name Tag to worker and manager instances for AWS

### DIFF
--- a/latest/swarm/aws/manager.json
+++ b/latest/swarm/aws/manager.json
@@ -8,7 +8,8 @@ Instance plugin config for managers on AWS
     "Properties": {
         "Tags": {
             "infrakit.clusterName": "{{ var "/cluster/name" }}",
-            "infrakit.role" : "managers"
+            "infrakit.role" : "managers",
+            "Name": "{{ var "/cluster/name" }}-manager"
         },
         "RunInstancesInput": {
             "BlockDeviceMappings": null,

--- a/latest/swarm/aws/worker.json
+++ b/latest/swarm/aws/worker.json
@@ -8,7 +8,8 @@ Config for workers on AWS
     "Properties": {
         "Tags": {
             "infrakit.clusterName": "{{ var "/cluster/name" }}",
-            "infrakit.role" : "workers"
+            "infrakit.role" : "workers",
+            "Name": "{{ var "/cluster/name" }}-worker"
         },
         "RunInstancesInput": {
             "BlockDeviceMappings": null,


### PR DESCRIPTION
Right now, when you use the AWS example and you login into the EC2 dashboard you will not see a Name of the instances that get created, this makes it hard to see what is going on. To fix this, we just need to add a "Name" tag to the instances. That is what this PR does. It adds a Name tag for the worker and managers with the format $ClusterName-[worker|manager]

@chungers not sure the best way to test this, any suggestions?

Signed-off-by: Ken Cochrane <kencochrane@gmail.com>